### PR TITLE
fix textsize scroller

### DIFF
--- a/bin/Scroller.py
+++ b/bin/Scroller.py
@@ -26,7 +26,7 @@ class Scroller:
 
             # Calculate width but skip drawing if off the left side of screen.
             if x < -10:
-                char_width, char_height = self.display.draw.textsize(c, font=self.font)
+                char_width, char_height = Utils.get_text_size(self.display, c, font=self.font)
                 x += char_width
                 continue
 
@@ -37,7 +37,7 @@ class Scroller:
             self.display.draw.text((x, y), c, font=self.font, fill=255)
 
             # Increment x position based on chacacter width.
-            char_width, char_height = self.display.draw.textsize(c, font=self.font)
+            char_width, char_height = Utils.get_text_size(self.display, c, font=self.font)
             x += char_width
 
     def move_for_next_frame(self, allow_startover):


### PR DESCRIPTION
## Description
textsize is deprecated, missed 2 lines in scroller

## Related Issue
This PR fixes or closes issue: fixes https://github.com/crismc/homeassistant_addons/issues/9

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.