### PR TITLE
get first interface with ipv4 or return 0.0.0.0 if none

### DIFF
--- a/bin/Utils.py
+++ b/bin/Utils.py
@@ -83,7 +83,11 @@ class HassioUtils(Utils):
     @staticmethod
     def get_ip():
         network_info = HassioUtils.hassos_get_info('network/info')
-        return network_info['data']['interfaces'][0]['ipv4']['address'][0].split("/")[0]
+        first_interface_with_ipv4 = next((interface for interface in network_info["data"]["interfaces"] if interface["ipv4"]["address"]), None)
+        if first_interface_with_ipv4:
+            return first_interface_with_ipv4["ipv4"]["address"][0].split("/")[0]
+        else:
+            return "0.0.0.0"
 
     @staticmethod
     def compile_text(text, additional_replacements = {}):


### PR DESCRIPTION
Signed-off-by: Simon Smith <simonsmith5521@gmail.com>

## Description
rpi4 has built in wifi, even tho its not used, the first interface seems to be the wifi, so no ipv4 address is defined

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
This PR fixes or closes issue: fixes https://github.com/crismc/homeassistant_addons/issues/8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.